### PR TITLE
Slight painshock threshold decrease

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -101,7 +101,7 @@ var/list/gamemode_cache = list()
 
 	//game_options.txt configs
 
-	var/health_threshold_dead = -100
+	var/health_threshold_dead = -90
 
 	var/organ_health_multiplier = 0.9
 	var/organ_regeneration_multiplier = 0.25


### PR DESCRIPTION
Decrease painshock treshold by 10 points (so 150 pain = painshock instead of 160)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
