### PR TITLE
Buff external limbs health

### DIFF
--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -8,8 +8,8 @@
 	name = "upper body"
 	organ_tag = BP_CHEST
 	icon_name = "torso"
-	max_damage = 100
-	min_broken_damage = 35
+	max_damage = 150
+	min_broken_damage = 65
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	body_part = UPPER_TORSO
 	vital = 1
@@ -40,8 +40,8 @@
 	name = "lower body"
 	organ_tag = BP_GROIN
 	icon_name = "groin"
-	max_damage = 100
-	min_broken_damage = 35
+	max_damage = 150
+	min_broken_damage = 65
 	w_class = ITEM_SIZE_LARGE
 	body_part = LOWER_TORSO
 	vital = 1
@@ -57,7 +57,7 @@
 	organ_tag = BP_L_ARM
 	name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 50
+	max_damage = 100
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 	body_part = ARM_LEFT
@@ -88,7 +88,7 @@
 	organ_tag = BP_L_LEG
 	name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 50
+	max_damage = 100
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 	body_part = LEG_LEFT
@@ -122,7 +122,7 @@
 	organ_tag = BP_L_FOOT
 	name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 30
+	max_damage = 80
 	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 	body_part = FOOT_LEFT
@@ -160,7 +160,7 @@
 	organ_tag = BP_L_HAND
 	name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 30
+	max_damage = 80
 	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 	body_part = HAND_LEFT


### PR DESCRIPTION
Buff all limbs (especially torso and health) to decrease chance of delimb, also increase break threshold for upper and lower chest so you can take a bullet without it breaking instantly

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
