### PR TITLE
Slight 5,56mm AP nerf  and others changes

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -129,8 +129,8 @@
 /obj/item/projectile/bullet/pistol
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	damage = 40 //9mm, .38, etc
-	armor_penetration = 25
-	agony = 35
+	armor_penetration = 34
+	agony = 34
 
 /obj/item/projectile/bullet/pistol/medium
 	damage = 50 //.45
@@ -141,7 +141,7 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	damage = 40 //10mm
 	armor_penetration = 30
-	agony = 31
+	agony = 35
 
 /obj/item/projectile/bullet/pistol/medium/smg/rubber
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
@@ -161,24 +161,24 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	damage = 35 //10mm AP
 	armor_penetration = 55
-	agony = 25
+	agony = 30
 
 /obj/item/projectile/bullet/pistol/medium/smg/silver
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
-	damage = 30 //10mm but i have no idea what bimmer wanted for classifaction, so i made it just better normal ammo
+	damage = 40 //10mm but i have no idea what bimmer wanted for classifaction, so i made it just better normal ammo
 	armor_penetration = 18
-	agony = 23
+	agony = 30
 
 /obj/item/projectile/bullet/pistol/medium/revolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 60 //.44 magnum or something
-	agony = 35
+	agony = 45
 
 /obj/item/projectile/bullet/pistol/strong //matebas
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 65 //.50AE
 	armor_penetration = 30
-	agony = 35
+	agony = 45
 
 /obj/item/projectile/bullet/pistol/vstrong //tacrevolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
@@ -189,7 +189,7 @@
 /obj/item/projectile/bullet/pistol/strong/revolver //revolvers
 	damage = 60 //Revolvers get snowflake bullets, to keep them relevant
 	armor_penetration = 20
-	agony = 36
+	agony = 45
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -207,8 +207,8 @@
 	name = "slug"
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
 	damage = 60
-	armor_penetration = 30
-	agony = 34
+	armor_penetration = 24
+	agony = 40
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -223,7 +223,7 @@
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
-	damage = 30
+	damage = 35
 	pellets = 6
 	range_step = 1
 	spread_step = 10
@@ -239,7 +239,7 @@
 /obj/item/projectile/bullet/rifle/a556
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
 	damage = 50
-	armor_penetration = 50
+	armor_penetration = 34
 	agony = 40
 
 /obj/item/projectile/bullet/rifle/a762


### PR DESCRIPTION
MTF Chest armour can now stop bleeding and shrapnel embed from getting shot in the chest with a 5,56
Fitting because ballistic plate are known to stop intermediary cartridges.

M16 is still a beast against anything less than MTF plate armour, and will still penetrate MTF helmet
(MTF armour value = 85, 80 for the helmet)
No change to 7,62, it will still pierce MTF armour altho not by much. 
Also changed some others stuff for weapons that are mostly unused, like buckshot for shotgun (now a point blank shot against someone who is unarmoured will be extremely lethal). 9mm pistols now fills the niche of a gun weaker than a .45 pistol but more effective against lightly armoured personnel (bullet will almost penetrated standard guard armour)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
