### PR TITLE
Various changes (Weapons + lockers loadout + new ammo boxes)

### DIFF
--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -119,7 +119,7 @@
 	name = "bandolier"
 	desc = "A lightweight synthethic bandolier with straps for holding ammunition or other small objects."
 	icon_state = "bandolier"
-	slots = 10
+	slots = 20
 	max_w_class = ITEM_SIZE_NORMAL
 
 /obj/item/clothing/accessory/storage/bandolier/New()

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -140,7 +140,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 600)
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	max_ammo = 15
+	max_ammo = 17
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/mc9mm/empty

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -157,7 +157,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 1800)
 	caliber = "9mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
-	max_ammo = 30
+	max_ammo = 150
 
 /obj/item/ammo_magazine/box/c9mm/empty
 	initial_ammo = 0
@@ -208,7 +208,17 @@
 	caliber = "a762"
 	matter = list(DEFAULT_WALL_MATERIAL = 2250)
 	ammo_type = /obj/item/ammo_casing/a762
-	max_ammo = 40
+	max_ammo = 150
+	multiple_sprites = 1
+	
+/obj/item/ammo_magazine/box/a10mm
+	name = "ammunition box (5.7 x 28 mm)"
+	icon_state = "usmc_box"
+	origin_tech = list(TECH_COMBAT = 2)
+	caliber = "10mm"
+	matter = list(DEFAULT_WALL_MATERIAL = 2250)
+	ammo_type = /obj/item/ammo_casing/a10mm
+	max_ammo = 200
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/box/c45donor
@@ -218,7 +228,17 @@
 	caliber = ".45"
 	matter = list(DEFAULT_WALL_MATERIAL = 2250)
 	ammo_type = /obj/item/ammo_casing/c45
-	max_ammo = 50
+	max_ammo = 100
+	multiple_sprites = 1
+	
+/obj/item/ammo_magazine/box/a50donor
+	name = "ammunition box (.50)"
+	icon_state = "ammobox"
+	origin_tech = list(TECH_COMBAT = 2)
+	caliber = ".50"
+	matter = list(DEFAULT_WALL_MATERIAL = 2250)
+	ammo_type = /obj/item/ammo_casing/a50
+	max_ammo = 90
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/box/c45donor/rubber
@@ -228,7 +248,7 @@
 	caliber = ".45"
 	matter = list(DEFAULT_WALL_MATERIAL = 2250)
 	ammo_type = /obj/item/ammo_casing/c45/rubber
-	max_ammo = 50
+	max_ammo = 100
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/box/a556alt
@@ -238,7 +258,7 @@
 	caliber = "a556"
 	matter = list(DEFAULT_WALL_MATERIAL = 2250)
 	ammo_type = /obj/item/ammo_casing/a556
-	max_ammo = 40
+	max_ammo = 150
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/box/c45
@@ -248,7 +268,7 @@
 	caliber = ".45"
 	matter = list(DEFAULT_WALL_MATERIAL = 2250)
 	ammo_type = /obj/item/ammo_casing/c45
-	max_ammo = 30
+	max_ammo = 100
 
 /obj/item/ammo_magazine/box/c45/empty
 	initial_ammo = 0

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -126,11 +126,11 @@
 		icon_state = "gyropistol"
 
 /obj/item/weapon/gun/projectile/pistol
-	name = "standard-issue handgun"
-	desc = "The Lumoco Arms P3 Whisper. A small, easily concealable gun. Uses 9mm rounds."
+	name = "MK9 Standard"
+	desc = "Standard issue 9mm pistol of the SCP Foundation, based on the makarov."
 	icon_state = "pistol"
 	item_state = null
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_NORMAL
 	caliber = "9mm"
 	silenced = 0
 	fire_delay = 1

--- a/maps/site53/structures/closets/security.dm
+++ b/maps/site53/structures/closets/security.dm
@@ -38,25 +38,26 @@
 		/obj/item/clothing/under/scp/utility/security,
 		/obj/item/clothing/head/helmet/scp/security,
 		/obj/item/device/flashlight/maglight,
+		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/clothing/suit/armor/vest/scp/medarmor,
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,
 		/obj/item/weapon/storage/belt/security/tactical,
-		/obj/item/weapon/gun/projectile/sec/sec,
-		/obj/item/ammo_magazine/c45m = 4,
 		/obj/item/weapon/gun/projectile/automatic/scp/p90,
 		/obj/item/ammo_magazine/scp/p90_mag = 2,
 		/obj/item/ammo_magazine/scp/p90_mag/rubber = 4,
+		/obj/item/ammo_magazine/box/a10mm,
 		/obj/item/weapon/melee/telebaton,
-		/obj/item/weapon/handcuffs,
-		/obj/item/ammo_magazine/box/c45donor,
-		/obj/item/ammo_magazine/box/c45donor/rubber,
+		/obj/item/weapon/handcuffs = 2,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/clothing/gloves/tactical/scp,
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/device/flash,
 		/obj/item/clothing/accessory/solgov/department/security/marine,
 		/obj/item/clothing/mask/balaclava,
-		/obj/item/weapon/storage/box/bloodtypes
+		/obj/item/weapon/storage/box/bloodtypes,
+		/obj/item/ammo_magazine/box/c9mm,
+		/obj/item/weapon/gun/projectile/pistol,
+		/obj/item/ammo_magazine/mc9mm = 4
 	)
 
 /obj/structure/closet/secure_closet/mtf/commander
@@ -75,13 +76,12 @@
 		/obj/item/clothing/suit/armor/vest/scp/pizdeckakoyarmor,
 		/obj/item/clothing/glasses/sunglasses/sechud/goggles,
 		/obj/item/weapon/storage/belt/security/tactical,
-		/obj/item/weapon/gun/projectile/sec/sec,
-		/obj/item/ammo_magazine/c45m = 4,
 		/obj/item/weapon/gun/projectile/automatic/scp/p90,
 		/obj/item/ammo_magazine/scp/p90_mag = 2,
 		/obj/item/ammo_magazine/scp/p90_mag/rubber = 4,
+		/obj/item/ammo_magazine/box/a10mm,
 		/obj/item/weapon/melee/telebaton,
-		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/handcuffs = 2,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/clothing/gloves/tactical/scp,
 		/obj/item/device/flash,
@@ -90,7 +90,13 @@
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/clothing/accessory/solgov/department/security/marine,
 		/obj/item/clothing/mask/balaclava,
-		/obj/item/weapon/storage/box/bloodtypes
+		/obj/item/weapon/storage/box/bloodtypes,
+		/obj/item/weapon/gun/projectile/revolver/mateba,
+		/obj/item/ammo_magazine/box/a50donor,
+		/obj/item/ammo_magazine/c50 = 2,
+		/obj/item/ammo_magazine/box/c9mm,
+		/obj/item/weapon/gun/projectile/pistol,
+		/obj/item/ammo_magazine/mc9mm = 2
 	)
 
 /obj/structure/closet/secure_closet/mtf/nco
@@ -114,8 +120,9 @@
 		/obj/item/weapon/gun/projectile/automatic/scp/p90,
 		/obj/item/ammo_magazine/scp/p90_mag = 2,
 		/obj/item/ammo_magazine/scp/p90_mag/rubber = 4,
+		/obj/item/ammo_magazine/box/a10mm,
 		/obj/item/weapon/melee/telebaton,
-		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/handcuffs = 2,
 		/obj/item/ammo_magazine/box/c45donor,
 		/obj/item/ammo_magazine/box/c45donor/rubber,
 		/obj/item/weapon/storage/box/ifak,
@@ -127,7 +134,9 @@
 		/obj/item/clothing/accessory/solgov/department/security/marine,
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/clothing/mask/balaclava,
-		/obj/item/weapon/storage/box/bloodtypes
+		/obj/item/weapon/storage/box/bloodtypes,
+		/obj/item/weapon/gun/projectile/pistol,
+		/obj/item/ammo_magazine/mc9mm = 2
 	)
 
 /obj/structure/closet/secure_closet/mtf/co
@@ -151,21 +160,23 @@
 		/obj/item/weapon/gun/projectile/automatic/scp/p90,
 		/obj/item/ammo_magazine/scp/p90_mag = 2,
 		/obj/item/ammo_magazine/scp/p90_mag/rubber = 4,
-		/obj/item/weapon/gun/projectile/sec/sec,
-		/obj/item/ammo_magazine/c45m = 4,
-		/obj/item/ammo_magazine/box/c45donor,
-		/obj/item/ammo_magazine/box/c45donor/rubber,
+		/obj/item/ammo_magazine/box/a10mm,
 		/obj/item/clothing/accessory/storage/webbing_large,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/clothing/accessory/solgov/department/security/marine,
-		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/handcuffs = 2,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/device/flash,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/clothing/gloves/tactical/scp,
 		/obj/item/clothing/accessory/holster/thigh,
 		/obj/item/clothing/mask/balaclava,
-		/obj/item/weapon/storage/box/bloodtypes
+		/obj/item/weapon/storage/box/bloodtypes,
+		/obj/item/weapon/gun/projectile/revolver/mateba,
+		/obj/item/ammo_magazine/box/a50donor,
+		/obj/item/ammo_magazine/c50 = 4,
+		/obj/item/weapon/gun/projectile/pistol,
+		/obj/item/ammo_magazine/mc9mm = 2
 	)
 
 /obj/structure/closet/secure_closet/mtf/breachautomatics
@@ -216,7 +227,8 @@
 /obj/structure/closet/secure_closet/mtf/riotshotguns/WillContain()
 	return list(
 		/obj/item/weapon/gun/projectile/shotgun/tactical/beanbag = 3,
-		/obj/item/weapon/storage/box/mtf/beanbag = 9
+		/obj/item/weapon/storage/box/mtf/beanbag = 9,
+		/obj/item/clothing/accessory/storage/bandolier
 	)
 
 /obj/structure/closet/secure_closet/mtf/attackby(var/obj/item/weapon/W, var/mob/user)


### PR DESCRIPTION
List of changes off the top of my head:
- 9mm pistol renamed and given normal size (to avoid storage in pocket)
- 9mm pistol is the standard pistol for junior guards who gets it alongside 4 mags and an ammo box
- 9mm pistol also spawns in ZCommander, Commander and regular Guards office in addition to standard .45 pistol
- 9mm pistol given a more fitting description and name (its not known as the "MK9 Standard" to match "MK18 Special" of the .45 pistol)
- Guard Commander and Zone Commanders are given mateba with matching ammo box and speedloaders
- All guard lockers recieve one 5.7x28 ammo box (technically 10mm) for their p90 reloading need
- Some ammo boxes had their bullet count doubled or tripled (5,56, 7,62, .45)
- Junior Guards gets black webbing same as regular guards
- Lockers spawns with 2 cuffs instead of 1
- New .50 and 10mm ammo box
