### PR TITLE
Zone Commander Locker Fixes

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -90,8 +90,8 @@
 	siemens_coefficient = 0.7
 
 /obj/item/clothing/head/helmet/swat
-	name = "\improper SWAT helmet"
-	desc = "They're often used by highly trained Swat Members."
+	name = "\improper Foundation Security Helmet"
+	desc = "They're often used by highly trained SCPF SD Troopers."
 	icon_state = "helmet_merc"
 	armor = list(melee = 80, bullet = 80, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	cold_protection = HEAD

--- a/maps/site53/structures/closets/security.dm
+++ b/maps/site53/structures/closets/security.dm
@@ -186,7 +186,7 @@
 	icon_opened = "nopen"
 	icon_off = "noff"
 
-/obj/structure/closet/secure_closet/mtf/co/WillContain()
+/obj/structure/closet/secure_closet/mtf/hczguard/WillContain()
 	return list(
 		/obj/item/weapon/storage/belt/security/tactical,
 		/obj/item/weapon/gun/projectile/automatic/scp/m16,
@@ -212,6 +212,7 @@
 		/obj/item/clothing/accessory/armguards,
 		/obj/item/clothing/accessory/armorplate/medium,
 		/obj/item/clothing/accessory/storage/pouches/large,
+		/obj/item/clothing/head/helmet/swat,
 		/obj/item/clothing/under/color/black
 	)
 
@@ -224,7 +225,7 @@
 	icon_opened = "enlistedopen"
 	icon_off = "enlistedoff"
 
-/obj/structure/closet/secure_closet/mtf/co/WillContain()
+/obj/structure/closet/secure_closet/mtf/hczguardjunior/WillContain()
 	return list(
 		/obj/item/weapon/storage/belt/security/tactical,
 		/obj/item/weapon/gun/projectile/automatic/scp/m16,
@@ -250,6 +251,7 @@
 		/obj/item/clothing/accessory/armguards,
 		/obj/item/clothing/accessory/armorplate/medium,
 		/obj/item/clothing/accessory/storage/pouches/large,
+		/obj/item/clothing/head/helmet/swat,
 		/obj/item/clothing/under/color/white
 	)
 
@@ -263,7 +265,7 @@
 	icon_opened = "coopen"
 	icon_off = "cooff"
 
-/obj/structure/closet/secure_closet/mtf/co/WillContain()
+/obj/structure/closet/secure_closet/mtf/hczguardzonecomm/WillContain()
 	return list(
 		/obj/item/weapon/storage/belt/security/tactical,
 		/obj/item/weapon/gun/projectile/automatic/z8,
@@ -289,6 +291,7 @@
 		/obj/item/clothing/accessory/armguards,
 		/obj/item/clothing/accessory/armorplate/medium,
 		/obj/item/clothing/accessory/storage/pouches/large,
+		/obj/item/clothing/head/helmet/swat,
 		/obj/item/clothing/under/color/red,
 		/obj/item/weapon/gun/projectile/revolver/mateba,
 		/obj/item/ammo_magazine/box/a50donor,


### PR DESCRIPTION
Fixes an issue where Guard Zone Commanders are given items from HCZ Guard Commander
Also fix the issue where HCZ lockers don't spawn with helmets.
Change name of SWAT helmet as well as description.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
