### PR TITLE
Experimental gun change

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 /obj/sprite_helper/scp049
 	icon = 'icons/mob/scp049.dmi'
 
-/mob/living/carbon/human/scp049/IsAdvancedToolUser()
+/mob/living/carbon/human/scp049/CanUseGuns()
 	return FALSE
 
 /mob/living/carbon/human/scp049/New()

--- a/code/modules/SCP/SCPs/SCP-343.dm
+++ b/code/modules/SCP/SCPs/SCP-343.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(scp343s)
 /obj/sprite_helper/scp343
 	icon = 'icons/mob/scp343.dmi'
 
-/mob/living/carbon/human/scp343/IsAdvancedToolUser()
+/mob/living/carbon/human/scp343/CanUseGuns()
 	return FALSE
 
 /mob/living/carbon/human/scp343/New()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -821,6 +821,9 @@
 /mob/proc/IsAdvancedToolUser()
 	return 0
 
+/mob/proc/CanUseGuns()
+	return 0
+
 /mob/proc/Stun(amount)
 	if(status_flags & CANSTUN)
 		facing_dir = null

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -116,6 +116,8 @@
 		return 0
 	if(!user.IsAdvancedToolUser())
 		return 0
+	if(!user.CanUseGuns())
+		return 0
 
 	var/mob/living/M = user
 	if(HULK in M.mutations)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -123,9 +123,7 @@
 	if(HULK in M.mutations)
 		to_chat(M, "<span class='danger'>Your fingers are much too large for the trigger guard!</span>")
 		return 0
-
-	if(isscp049(user))
-		return 0
+		
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))


### PR DESCRIPTION
Added a new proc called /mob/proc/CanUseGuns(). It works exactly like the IsAdvancedToolUser() proc except that it is only checked when trying to fire a gun. I also replaced the IsAdvancedToolUser() bit in both 343 and 049s code with the new proc.

In theory this means that both are now able to interact with everything around them like a normal human player while not being able to fire any guns whatsoever.
In practice my laptop is too shit to properly run a local server so I wasn't able to test this.