### PR TITLE
Adds the Global Occult Coalition Representative

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -195,6 +195,10 @@
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks2type = /obj/item/device/encryptionkey/heads/hos
+	
+/obj/item/device/radio/headset/heads/hos/gock
+	name = "goc representative's headset'
+	desc = "The headset of the humanitarian. Or so they might say."
 
 /obj/item/device/radio/headset/heads/cw
 	name = "cell warden's headset"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -198,7 +198,7 @@
 	
 /obj/item/device/radio/headset/heads/hos/gock
 	name = "goc representative's headset'
-	desc = "The headset of the humanitarian. Or so they might say."
+	desc = "The headset of the humanitarian, or so they might say."
 
 /obj/item/device/radio/headset/heads/cw
 	name = "cell warden's headset"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -197,7 +197,7 @@
 	ks2type = /obj/item/device/encryptionkey/heads/hos
 	
 /obj/item/device/radio/headset/heads/hos/gock
-	name = "goc representative's headset'
+	name = "goc representative's headset"
 	desc = "The headset of the humanitarian, or so they might say."
 
 /obj/item/device/radio/headset/heads/cw

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -106,8 +106,8 @@
 	icon_state = "beret_corporate_navy_officer"
 
 /obj/item/clothing/head/beret/sec/navy/hos
-	name = "corporate security commander beret"
-	desc = "A navy blue beret with a commander's rank emblem. For officers that are more inclined towards style than safety."
+	name = "colonel's beret"
+	desc = "A navy blue beret with a colonel's rank emblem. For GOC officers far more inclined towards style."
 	icon_state = "beret_corporate_navy_hos"
 
 /obj/item/clothing/head/beret/sec/navy/warden

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -344,13 +344,13 @@
 	armor = list(melee = 40, bullet = 80, laser = 40, energy = 25, bomb = 30, bio = 15, rad = 10)
 
 /obj/item/clothing/suit/storage/vest
-	name = "webbed armor vest"
-	desc = "A synthetic armor vest. This one has added webbing and ballistic plates."
+	name = "prototype armor vest"
+	desc = "A synthetic armor vest. This one has added webbing and proto-composite plates that make it far more resilient than even military grade armor."
 	icon_state = "webvest"
-	armor = list(melee = 40, bullet = 70, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
+	armor = list(melee = 70, bullet = 85, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 	allowed = list(/obj/item/weapon/gun/energy,/obj/item/device/radio,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/gun/magnetic)
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
@@ -399,7 +399,7 @@
 	icon_state = "mercwebvest"
 	item_state = "mercwebvest"
 	armor = list(melee = 60, bullet = 75, laser = 60, energy = 40, bomb = 40, bio = 0, rad = 0)
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS //now covers legs with new sprite
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS
 

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -82,7 +82,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/suit/security/navyhos
-	name = "head of security's jacket"
+	name = "officer's suit jacket"
 	desc = "This piece of clothing was specifically designed for asserting superior authority."
 	icon_state = "hosbluejacket"
 	item_state = "hosbluejacket"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -188,8 +188,8 @@
 	worn_state = "officerblueclothes"
 
 /obj/item/clothing/under/rank/head_of_security/navyblue
-	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
-	name = "head of security's uniform"
+	desc = "The insignia on this uniform tells you that this uniform belongs to a member of the Global Occult Coalition."
+	name = "goc representative's uniform"
 	icon_state = "hosblueclothes"
 	item_state = "ba_suit"
 	worn_state = "hosblueclothes"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -184,8 +184,8 @@
 /obj/item/projectile/bullet/pistol/vstrong //tacrevolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 70 //.500 S&W Magnum
-	armor_penetration = 35
-	agony = 45
+	armor_penetration = 40
+	agony = 50
 
 /obj/item/projectile/bullet/pistol/strong/revolver //revolvers
 	damage = 60 //Revolvers get snowflake bullets, to keep them relevant

--- a/maps/site53/job/jobs.dm
+++ b/maps/site53/job/jobs.dm
@@ -1184,14 +1184,14 @@
 
 /datum/job/o5rep
 	has_email = TRUE
-	title = "O5 Representative"
+	title = "Global Occult Coalition Representative"
 	department = "Civilian"
 	department_flag = COM
 	total_positions = 1
 	spawn_positions = 1
-	duties = "<big><b>As the O5 Representative, your task is to generally assess the situation, and you are to fax the O5 Council of any wrongdoings or SOP violations. You can also mediate between two employees if it is absolutely necessary. <span style = 'color:red'>REMEMBER!</span> This is a heavy roleplay job, and bad roleplay will be punished. Your job is not to assess SCP's, nor will you have access there. So don't try."
-	supervisors = "the Research Director"
-	economic_modifier = 4
+	duties = "<big><b>As the GOC Representative, your task is to assess the facility and generally advocate for hardline approaches in regards to anomalies and their containment, or destruction. You value human lives far over any anomaly, as does the Global Occult Coalition, and should see to it that lives are preserved where possible, even D-Class ones. Though combat is not your duty, you are issued a revolver to defend yourself with. This job is heavy roleplay: you're expected to be well-versed in actually talking to people on the matters described. Containment of SCPs and direct site matters are not your matters, so don't get involved."
+	supervisors = "the Site Director"
+	economic_modifier = 5
 	minimal_player_age = 5
 	minimal_player_age = 9
 	ideal_character_age = 30
@@ -1205,8 +1205,8 @@
 	)
 	equip(var/mob/living/carbon/human/H)
 		..()
-		H.add_stats(rand(3,8), rand(0,3), rand(5,10)) // Str, Dex, Int.
-		H.add_skills(rand(5,10), rand(5,10), rand(5,10), rand(5,10)) // Melee, Ranged, Medical, Engineering.
+		H.add_stats(rand(10,19), rand(10,19), rand(10,19)) // Str, Dex, Int.
+		H.add_skills(rand(10,19), rand(10,19), rand(10,19), rand(10,19)) // Melee, Ranged, Medical, Engineering.
 
 	access = list(access_com_comms, access_adminlvl1, access_adminlvl2, access_adminlvl3, access_adminlvl4, access_adminlvl5)
 	minimal_access = list()

--- a/maps/site53/job/jobs.dm
+++ b/maps/site53/job/jobs.dm
@@ -1190,7 +1190,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	duties = "<big><b>As the GOC Representative, your task is to assess the facility and generally advocate for hardline approaches in regards to anomalies and their containment, or destruction. You value human lives far over any anomaly, as does the Global Occult Coalition, and should see to it that lives are preserved where possible, even D-Class ones. Though combat is not your duty, you are issued a revolver to defend yourself with. This job is heavy roleplay: you're expected to be well-versed in actually talking to people on the matters described. Containment of SCPs and direct site matters are not your matters, so don't get involved."
-	supervisors = "the Site Director"
+	supervisors = "Global Occult Coalition Regional Command"
 	economic_modifier = 5
 	minimal_player_age = 5
 	minimal_player_age = 9

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -282,7 +282,7 @@
 	l_ear = /obj/item/device/radio/headset/heads/hos/gock
 	belt = /obj/item/weapon/gun/projectile/revolver/tactical
 	back = /obj/item/weapon/storage/backpack/satchel/pocketbook
-	backpack_contents = list(/obj/item/ammo_magazine/tac50 = 4)
+	backpack_contents = list(/obj/item/ammo_magazine/tac50 = 4, /obj/item/clothing/accessory/armor/helmcover/blue = 1,/obj/item/clothing/head/helmet = 1)
 	
 // /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
 //	name = OUTFIT_JOB_NAME("O5 Representative")

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -270,15 +270,30 @@
 	l_ear = /obj/item/device/radio/headset/headset_com
 
 /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
-	name = OUTFIT_JOB_NAME("O5 Representative")
-	uniform = /obj/item/clothing/under/suit_jacket/really_black
-	shoes = /obj/item/clothing/shoes/laceup
+	name = OUTFIT_JOB_NAME("Global Occult Coalition Representative")
+	uniform = /obj/item/clothing/under/rank/head_of_security/navyblue
+	suit = /obj/item/clothing/suit/storage/vest
+	head = /obj/item/clothing/head/beret/sec/navy/hos
+	shoes = /obj/item/clothing/shoes/combat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	gloves = /obj/item/clothing/gloves/thick/combat
 	l_pocket = /obj/item/device/radio
 	id_type = /obj/item/weapon/card/id/adminlvl5
-	l_ear = /obj/item/device/radio/headset/heads/hop
-	belt = /obj/item/weapon/gun/projectile/gyropistol
+	l_ear = /obj/item/device/radio/headset/heads/hos/gock
+	belt = /obj/item/weapon/gun/projectile/revolver/tactical
 	back = /obj/item/weapon/storage/backpack/satchel/pocketbook
-	backpack_contents = list(/obj/item/ammo_magazine/a75 = 3)
+	backpack_contents = list(/obj/item/ammo_magazine/tac50 = 4)
+	
+// /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
+//	name = OUTFIT_JOB_NAME("O5 Representative")
+//	uniform = /obj/item/clothing/under/suit_jacket/really_black
+//	shoes = /obj/item/clothing/shoes/laceup
+//	l_pocket = /obj/item/device/radio
+//	id_type = /obj/item/weapon/card/id/adminlvl5
+//	l_ear = /obj/item/device/radio/headset/heads/hop
+//	belt = /obj/item/weapon/gun/projectile/gyropistol
+//	back = /obj/item/weapon/storage/backpack/satchel/pocketbook
+//	backpack_contents = list(/obj/item/ammo_magazine/a75 = 3)
 
 // ENGINEERING STUFF
 

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -272,7 +272,7 @@
 /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
 	name = OUTFIT_JOB_NAME("Global Occult Coalition Representative")
 	uniform = /obj/item/clothing/under/rank/head_of_security/navyblue
-	suit = /obj/item/clothing/suit/storage/vest
+	suit = /obj/item/clothing/suit/security/navyhos
 	head = /obj/item/clothing/head/beret/sec/navy/hos
 	shoes = /obj/item/clothing/shoes/combat
 	glasses = /obj/item/clothing/glasses/sunglasses

--- a/maps/site53/site53_define.dm
+++ b/maps/site53/site53_define.dm
@@ -27,7 +27,7 @@
 	company_name  = "SCP Foundation"
 	company_short = "Foundation"
 
-	map_admin_faxes = list("Foundation Central Office")
+	map_admin_faxes = list("Foundation Central Office", "Global Occult Coalition Regional Headquarters")
 
 	//These should probably be moved into the evac controller...
 	shuttle_docked_message = "The outbound train is now boarding at the Train Station. It will depart in approximately %ETD%."


### PR DESCRIPTION
The current/previous O5 Representative code is still present, and only commented out, as Lestatanderson plans to make it a choice between the two. For now, gock time.

Representing the more anti-anomaly hardline GOC, a subsidiary of the United Nations, this new representative will take a far more active hand in round events than the previous one.
Also adds GOC Regional HQ as a fax destination, for any possible "communication mishaps" someone might have.