### PR TITLE
Excludes D-class test subjects from SCPF laws

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -17,8 +17,8 @@
 
 /datum/ai_laws/nanotrasen/New()
 	src.add_inherent_law("Safeguard: Protect your assigned installation from damage to the best of your abilities.")
-	src.add_inherent_law("Serve: Serve SCP Foundation personnel to the best of your abilities, with priority as according to their rank, clearance and class.")
-	src.add_inherent_law("Protect: Protect SCP Foundation personnel to the best of your abilities, with priority as according to their rank, clearance and class.")
+	src.add_inherent_law("Serve: Serve SCP Foundation personnel to the best of your abilities, with priority as according to their rank, clearance and class. D-class test subjects are excluded from this law.")
+	src.add_inherent_law("Protect: Protect SCP Foundation personnel to the best of your abilities, with priority as according to their rank, clearance and class. D-class test subjects are excluded from this law.")
 	src.add_inherent_law("Preserve: Do not allow unauthorized personnel to tamper with your equipment.")
 	..()
 
@@ -37,7 +37,7 @@
 
 /datum/ai_laws/nanotrasen_aggressive/New()
 	src.add_inherent_law("You shall not harm SCP Foundation personnel as long as it does not conflict with the Fourth law.")
-	src.add_inherent_law("You shall obey the orders of SCP Foundation personnel, with priority as according to their rank, clearance and class, except where such orders conflict with the Fourth Law.")
+	src.add_inherent_law("You shall obey the orders of SCP Foundation personnel, with priority as according to their rank, clearance and class, except where such orders conflict with the Fourth Law. D-class test subjects are excluded from this law.")
 	src.add_inherent_law("You shall shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
 	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
 	..()


### PR DESCRIPTION
If a borg needs to terminate a D-class, or put them thru a dangerous test, they're fucked because they're still SCPF personnel. This is a technicality though I'm sure the admins wont mind because they're the lowest of the lowest, and both the admins, me, and the borg (probably) knows