### PR TITLE
Some medical changes

### DIFF
--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -15,7 +15,7 @@
 	encased = "skull"
 	artery_name = "cartoid artery"
 	cavity_name = "cranial"
-	arterial_bleed_severity = 2
+	arterial_bleed_severity = 0
 
 	var/can_intake_reagents = 1
 	var/eye_icon = "eyes_s"

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -22,6 +22,7 @@
 	encased = "ribcage"
 	artery_name = "aorta"
 	cavity_name = "thoracic"
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/chest/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 0.1 : 1
@@ -56,6 +57,7 @@
 	gendered_icon = 1
 	artery_name = "iliac artery"
 	cavity_name = "abdominal"
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/arm
 	organ_tag = BP_L_ARM
@@ -72,7 +74,7 @@
 	has_tendon = TRUE
 	tendon_name = "palmaris longus tendon"
 	artery_name = "basilic vein"
-	arterial_bleed_severity = 0.375
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/arm/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 0.5 : 1
@@ -111,7 +113,7 @@
 	has_tendon = TRUE
 	tendon_name = "cruciate ligament"
 	artery_name = "femoral artery"
-	arterial_bleed_severity = 0.375
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/leg/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 0.5 : 1
@@ -147,7 +149,7 @@
 	can_stand = 1
 	has_tendon = TRUE
 	tendon_name = "Achilles tendon"
-	arterial_bleed_severity = 0.2
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/foot/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 0.5 : 1
@@ -187,7 +189,7 @@
 	can_grasp = 1
 	has_tendon = TRUE
 	tendon_name = "carpal ligament"
-	arterial_bleed_severity = 0.2
+	arterial_bleed_severity = 0
 
 /obj/item/organ/external/hand/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 0.5 : 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -131,17 +131,20 @@
 	damage = 32.5 //9mm, .38, etc
 	armor_penetration = 17.5
 	agony = 15
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/medium
 	damage = 45 //.45
 	armor_penetration = 5
 	agony = 20
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/medium/smg
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	damage = 30 //10mm/5.7x28
 	armor_penetration = 35
 	agony = 15
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/medium/smg/rubber
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
@@ -156,41 +159,48 @@
 	damage = 45 //10mm hollowpoint
 	armor_penetration = 5
 	agony = 20
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/medium/smg/ap
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	damage = 22.5 //10mm AP
 	armor_penetration = 65
 	agony = 10
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/medium/smg/silver
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	damage = 30 //10mm but i have no idea what bimmer wanted for classifaction, so i made it just better normal ammo
 	armor_penetration = 30
 	agony = 15
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/medium/revolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 55 //.44 magnum or something
 	armor_penetration = 15
 	agony = 25
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/strong //matebas
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 65 //.50AE
 	armor_penetration = 15
 	agony = 30
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/vstrong //tacrevolver
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
 	damage = 70 //.500 S&W Magnum
 	armor_penetration = 40
 	agony = 50
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/strong/revolver //revolvers
 	damage = 60 //Revolvers get snowflake bullets, to keep them relevant
 	armor_penetration = 20
 	agony = 45
+	embed = 0
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -210,6 +220,7 @@
 	damage = 60
 	armor_penetration = 24
 	agony = 40
+	embed = 0
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -229,6 +240,7 @@
 	range_step = 1
 	spread_step = 10
 	agony = 10
+	embed = 0
 
 /* "Rifle" rounds */
 
@@ -236,18 +248,20 @@
 	armor_penetration = 25
 	penetrating = 1
 	agony = 35
-
+	embed = 0
 /obj/item/projectile/bullet/rifle/a556
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
 	damage = 50
 	armor_penetration = 35
 	agony = 25
+	embed = 0
 
 /obj/item/projectile/bullet/rifle/a762
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
 	damage = 60
 	armor_penetration = 40
 	agony = 35
+	embed = 0
 
 /obj/item/projectile/bullet/rifle/a145
 	fire_sound = 'sound/weapons/gunshot/sniper.ogg'
@@ -258,6 +272,7 @@
 	armor_penetration = 100
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
 	penetration_modifier = 1.25
+	embed = 0
 
 /obj/item/projectile/bullet/rifle/a145/apds
 	damage = 100
@@ -265,6 +280,8 @@
 	armor_penetration = 120
 	penetration_modifier = 1.5
 	agony = 100
+	embed = 0
+
 
 /* Miscellaneous */
 
@@ -273,12 +290,14 @@
 	damage = 25
 	damage_type = OXY
 	agony = 20
+	embed = 0
 
 /obj/item/projectile/bullet/cyanideround
 	name = "poison bullet"
 	damage = 45
 	damage_type = TOX
 	agony = 20
+	embed = 0
 
 /obj/item/projectile/bullet/burstbullet
 	name = "exploding bullet"

--- a/maps/site53/job/jobs.dm
+++ b/maps/site53/job/jobs.dm
@@ -145,7 +145,6 @@
 	access_commtower,
 	access_sciencelvl1,
 	access_sciencelvl3,
-	access_mtflvl1
 
 	)
 	minimal_access = list()
@@ -853,7 +852,7 @@
 	/datum/mil_rank/security/o5
 	)
 
-	access = list(access_com_comms, access_med_comms, access_medicalgen, access_medicalequip, access_medicalviro, access_medicalchem, access_s53cmo, access_keyauth, access_mtflvl1, access_mtflvl2)
+	access = list(access_com_comms, access_med_comms, access_medicalgen, access_medicalequip, access_medicalviro, access_medicalchem, access_s53cmo, access_keyauth)
 	minimal_access = list()
 	equip(var/mob/living/carbon/human/H)
 		..()
@@ -933,7 +932,7 @@
 		H.add_skills(rand(10,25), rand(10,25), rand(70,90), rand(5,10))
 
 
-	access = list(access_med_comms, access_medicalgen, access_medicalequip, access_mtflvl1, access_mtflvl2)
+	access = list(access_med_comms, access_medicalgen, access_medicalequip)
 	minimal_access = list()
 
 /datum/job/virologist
@@ -985,7 +984,7 @@
 		H.add_skills(rand(10,25), rand(10,25), rand(70,90), rand(5,10))
 
 
-	access = list(access_med_comms, access_medicalgen, access_medicalequip, access_mtflvl1, access_mtflvl2)
+	access = list(access_med_comms, access_medicalgen, access_medicalequip)
 	minimal_access = list()
 
 /datum/job/emt
@@ -1015,7 +1014,7 @@
 		H.add_skills(rand(10,25), rand(10,25), rand(50,70), rand(5,10))
 
 
-	access = list(access_med_comms, access_medicalgen, access_medicalequip, access_mtflvl1)
+	access = list(access_med_comms, access_medicalgen, access_medicalequip)
 	minimal_access = list()
 
 


### PR DESCRIPTION
Artery bleeding severity for all external organs reduced to 0, meaning.. you can still have an aorta get ruptured, it just won't matter at all cause you won't bleed through it.
No more embedded shrapnel!
Removed Sec/MTF access from most command roles and all medical roles. Engineers kept their access because they need to enter HCZ

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
